### PR TITLE
Add automated testing on Python 3.6 and 3.7 on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,20 @@
+group: travis_latest
+dist: xenial  # ubuntu-16.04
+language: python
+cache: pip
+python:
+  - 3.6
+  - 3.7
+install:
+  - pip install flake8
+  - pip install -r requirements.txt
+before_script:
+  # stop the build if there are Python syntax errors or undefined names
+  - flake8 . --count --select=E9,F63,F72,F82 --show-source --statistics
+  # exit-zero treats all errors as warnings.  The GitHub editor is 127 chars wide
+  - flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+script:
+  - true  # add other tests here
+notifications:
+  on_success: change
+  on_failure: change  # `always` will be the setting once code changes slow down


### PR DESCRIPTION
The owner of the this repo would need to go to https://travis-ci.com/profile, log in with GitHub credentials, select the __free plan__, and flip the repository switch __on__ to enable free automated testing of all pull requests.  Travis will lint with flake8 and then run whatever tests are in the __script:__ section.