### PR TITLE
from model.nms_wrapper import nms for lines 132 and 168

### DIFF
--- a/src/tools/voc_eval_lib/model/test.py
+++ b/src/tools/voc_eval_lib/model/test.py
@@ -21,7 +21,7 @@ from utils.blob import im_list_to_blob
 
 from model.config import cfg, get_output_dir
 from model.bbox_transform import clip_boxes, bbox_transform_inv
-# from model.nms_wrapper import nms
+from model.nms_wrapper import nms
 
 def _get_image_blob(im):
   """Converts an image into a network input.


### PR DESCRIPTION
[flake8](http://flake8.pycqa.org) testing of https://github.com/xingyizhou/CenterNet on Python 3.7.1

$ __flake8 . --count --select=E9,F63,F72,F82 --show-source --statistics__
```
./src/lib/models/networks/dlav0.py:417:5: F821 undefined name 'dla'
    dla.BatchNorm = bn
    ^
./src/tools/voc_eval_lib/model/test.py:132:14: F821 undefined name 'nms'
      keep = nms(dets, thresh)
             ^
./src/tools/voc_eval_lib/model/test.py:168:14: F821 undefined name 'nms'
      keep = nms(cls_dets, cfg.TEST.NMS)
             ^
3     F821 undefined name 'dla'
3
```
__E901,E999,F821,F822,F823__ are the "_showstopper_" [flake8](http://flake8.pycqa.org) issues that can halt the runtime with a SyntaxError, NameError, etc. These 5 are different from most other flake8 issues which are merely "style violations" -- useful for readability but they do not effect runtime safety.
* F821: undefined name `name`
* F822: undefined name `name` in `__all__`
* F823: local variable name referenced before assignment
* E901: SyntaxError or IndentationError
* E999: SyntaxError -- failed to compile a file into an Abstract Syntax Tree