### PR TITLE
Revert "from model.nms_wrapper import nms for lines 132 and 168"

### DIFF
--- a/src/tools/voc_eval_lib/model/test.py
+++ b/src/tools/voc_eval_lib/model/test.py
@@ -21,7 +21,7 @@ from utils.blob import im_list_to_blob
 
 from model.config import cfg, get_output_dir
 from model.bbox_transform import clip_boxes, bbox_transform_inv
-from model.nms_wrapper import nms
+# from model.nms_wrapper import nms
 
 def _get_image_blob(im):
   """Converts an image into a network input.


### PR DESCRIPTION
Reverts xingyizhou/CenterNet#13. You will need to compile cython nms before import nms, which is not needed in pascal evaluation. 