### PR TITLE
 The FocalLoss implementation uses dangerous log function.

### DIFF
--- a/src/lib/models/losses.py
+++ b/src/lib/models/losses.py
@@ -14,7 +14,7 @@ from .utils import _tranpose_and_gather_feat
 import torch.nn.functional as F
 
 
-def _slow_neg_loss(pred, gt):
+def _slow_neg_loss(pred, gt, eps=1e-7):
   '''focal loss from CornerNet'''
   pos_inds = gt.eq(1)
   neg_inds = gt.lt(1)
@@ -25,8 +25,8 @@ def _slow_neg_loss(pred, gt):
   pos_pred = pred[pos_inds]
   neg_pred = pred[neg_inds]
 
-  pos_loss = torch.log(pos_pred) * torch.pow(1 - pos_pred, 2)
-  neg_loss = torch.log(1 - neg_pred) * torch.pow(neg_pred, 2) * neg_weights
+  pos_loss = torch.log(pos_pred + eps) * torch.pow(1 - pos_pred, 2)
+  neg_loss = torch.log(1 - neg_pred + eps) * torch.pow(neg_pred, 2) * neg_weights
 
   num_pos  = pos_inds.float().sum()
   pos_loss = pos_loss.sum()
@@ -39,7 +39,7 @@ def _slow_neg_loss(pred, gt):
   return loss
 
 
-def _neg_loss(pred, gt):
+def _neg_loss(pred, gt, eps=1e-7):
   ''' Modified focal loss. Exactly the same as CornerNet.
       Runs faster and costs a little bit more memory
     Arguments:
@@ -53,8 +53,8 @@ def _neg_loss(pred, gt):
 
   loss = 0
 
-  pos_loss = torch.log(pred) * torch.pow(1 - pred, 2) * pos_inds
-  neg_loss = torch.log(1 - pred) * torch.pow(pred, 2) * neg_weights * neg_inds
+  pos_loss = torch.log(pred + eps) * torch.pow(1 - pred, 2) * pos_inds
+  neg_loss = torch.log(1 - pred + eps) * torch.pow(pred, 2) * neg_weights * neg_inds
 
   num_pos  = pos_inds.float().sum()
   pos_loss = pos_loss.sum()
@@ -66,7 +66,7 @@ def _neg_loss(pred, gt):
     loss = loss - (pos_loss + neg_loss) / num_pos
   return loss
 
-def _not_faster_neg_loss(pred, gt):
+def _not_faster_neg_loss(pred, gt, eps=1e-7):
     pos_inds = gt.eq(1).float()
     neg_inds = gt.lt(1).float()    
     num_pos  = pos_inds.float().sum()
@@ -75,7 +75,7 @@ def _not_faster_neg_loss(pred, gt):
     loss = 0
     trans_pred = pred * neg_inds + (1 - pred) * pos_inds
     weight = neg_weights * neg_inds + pos_inds
-    all_loss = torch.log(1 - trans_pred) * torch.pow(trans_pred, 2) * weight
+    all_loss = torch.log(1 - trans_pred + eps) * torch.pow(trans_pred, 2) * weight
     all_loss = all_loss.sum()
 
     if num_pos > 0:


### PR DESCRIPTION
I think now implementation get `-inf` when `pred` contains exact 0 or 1 value.