### PR TITLE
Minor fix

### DIFF
--- a/src/lib/trains/ctdet.py
+++ b/src/lib/trains/ctdet.py
@@ -59,7 +59,7 @@ class CtdetLoss(torch.nn.Module):
             output['wh'], batch['cat_spec_mask'],
             batch['ind'], batch['cat_spec_wh']) / opt.num_stacks
         else:
-          wh_loss += self.crit_reg(
+          wh_loss += self.crit_wh(
             output['wh'], batch['reg_mask'],
             batch['ind'], batch['wh']) / opt.num_stacks
       


### PR DESCRIPTION
Using `self.crit_reg` here  doesn't matter with the result, because `self.crit_reg` is same with `self.crit_wh`.

https://github.com/xingyizhou/CenterNet/blob/9efed05d531922b001b101c648c7ac5af3a9dafb/src/lib/trains/ctdet.py#L62-L64

But modify it to `self.crit_wh` is more clear for user to distinguish this two loss for it is in the condition of `if opt.wh_weight > 0`.