### PR TITLE
Fix 3D box orientation post-processing

### DIFF
--- a/src/lib/utils/post_process.py
+++ b/src/lib/utils/post_process.py
@@ -15,8 +15,8 @@ def get_alpha(rot):
   #                 bin2_cls[0], bin2_cls[1], bin2_sin, bin2_cos]
   # return rot[:, 0]
   idx = rot[:, 1] > rot[:, 5]
-  alpha1 = np.arctan(rot[:, 2] / rot[:, 3]) + (-0.5 * np.pi)
-  alpha2 = np.arctan(rot[:, 6] / rot[:, 7]) + ( 0.5 * np.pi)
+  alpha1 = np.arctan2(rot[:, 2], rot[:, 3]) + (-0.5 * np.pi)
+  alpha2 = np.arctan2(rot[:, 6], rot[:, 7]) + ( 0.5 * np.pi)
   return alpha1 * idx + alpha2 * (1 - idx)
   
 


### PR DESCRIPTION
Use arctan2 instead of arctan to convert sine and cosine to alpha.

**AOS:**

| Category | Easy | Medium | Hard |
| - | - | - | - |
| Car | 93.92 → 94.01 | 84.29 → 84.42 | 75.67 → 75.79 |
| Pedestrian | 52.55 → 53.75 | 45.64 → 46.51 | 39.15 → 39.81 |